### PR TITLE
Logging errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serialize = ["serde", "serde_derive"]
 [dependencies]
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
+log = { version = "0.3", optional = true }

--- a/debug-plugin/Cargo.toml
+++ b/debug-plugin/Cargo.toml
@@ -8,4 +8,4 @@ description = "An example/debug OpenVPN plugin. Showing the features of openvpn-
 crate-type = ["cdylib"]
 
 [dependencies]
-openvpn-plugin = { path = "../" }
+openvpn-plugin = { path = "../", features = ["log"] }

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -41,7 +41,7 @@ openvpn_plugin!(::openvpn_open, ::lol::openvpn_close, ::openvpn_event, ());
 fn openvpn_open(
     args: &[CString],
     env: &HashMap<CString, CString>,
-) -> Result<(Vec<OpenVpnPluginEvent>, ()), ()> {
+) -> Result<(Vec<OpenVpnPluginEvent>, ()), ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: open called:\n\targs: {:?}\n\tenv: {:?}",
         args,
@@ -61,7 +61,7 @@ fn openvpn_event(
     args: &[CString],
     env: &HashMap<CString, CString>,
     _handle: &mut (),
-) -> Result<SuccessType, ()> {
+) -> Result<SuccessType, ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: event called:\n\tevent: {:?}\n\targs: {:?}\n\tenv: {:?}",
         event,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,10 @@ extern crate serde;
 #[cfg(feature = "serialize")]
 extern crate serde_derive;
 
+#[cfg_attr(feature = "log", macro_use)]
+#[cfg(feature = "log")]
+extern crate log;
+
 /// FFI types and functions used by the plugin to convert between the types OpenVPN pass and expect
 /// back and the Rust types the plugin will be exposed to.
 ///
@@ -212,7 +216,10 @@ macro_rules! openvpn_plugin {
                         }
                         OPENVPN_PLUGIN_FUNC_SUCCESS
                     },
-                    Err(_e) => OPENVPN_PLUGIN_FUNC_ERROR,
+                    Err(e) => {
+                        $crate::log_error(e);
+                        OPENVPN_PLUGIN_FUNC_ERROR
+                    },
                 }
             }
 
@@ -255,10 +262,47 @@ macro_rules! openvpn_plugin {
                 match result {
                     Ok(SuccessType::Success) => OPENVPN_PLUGIN_FUNC_SUCCESS,
                     Ok(SuccessType::Deferred) => OPENVPN_PLUGIN_FUNC_DEFERRED,
-                    Err(_) => OPENVPN_PLUGIN_FUNC_ERROR,
+                    Err(e) => {
+                        $crate::log_error(e);
+                        OPENVPN_PLUGIN_FUNC_ERROR
+                    },
                 }
             }
         }
+        // Export the openvpn_plugin_* FFI functions in the top level scope
         pub use openvpn_plugin_ffi::*;
     }
+}
+
+
+
+/// Error logging method used by the FFI functions to log if `$open_fn` or `$event_fn` returns an
+/// error. This version logs using the `error!` macro of the log crate. Compile without the `log`
+/// feature to make it print to stderr.
+#[cfg(feature = "log")]
+pub fn log_error<E: ::std::error::Error>(error: E) {
+    error!("{}", format_error(error));
+}
+
+/// Error logging method used by the FFI functions to log if `$open_fn` or `$event_fn` returns an
+/// error. This version only prints to stdout. Build the crate with the `log` feature to log using
+/// the `error!` macro.
+#[cfg(not(feature = "log"))]
+pub fn log_error<E: ::std::error::Error>(error: E) {
+    use std::io::{self, Write};
+    let error_msg = format!("{}\n", format_error(error));
+
+    let mut stderr = io::stderr();
+    let _ = stderr.write_all(error_msg.as_bytes());
+    let _ = stderr.flush();
+}
+
+fn format_error<E: ::std::error::Error>(error: E) -> String {
+    let mut error_string = format!("Error: {}", error);
+    let mut error_iter = error.cause();
+    while let Some(e) = error_iter {
+        error_string.push_str(&format!("\nCaused by: {}", e));
+        error_iter = e.cause();
+    }
+    error_string
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! Also in your crate root (`lib.rs`) define your handle type, the three callback functions and
 //! call the `openvpn_plugin!` macro to generate the corresponding FFI bindings.
 //! More details on the handle and the callback functions can be found in the documentation for the
-//! `openvpn_plugin!` macro.
+//! [`openvpn_plugin!`](macro.openvpn_plugin.html) macro.
 //!
 //! ```rust,ignore
 //! pub struct Handle {
@@ -43,9 +43,9 @@
 //! }
 //!
 //! fn openvpn_open(
-//!     _args: &[CString],
-//!     _env: &HashMap<CString, CString>,
-//! ) -> Result<(Vec<openvpn_plugin::types::OpenVpnPluginEvent>, Handle, ()> {
+//!     args: &[CString],
+//!     env: &HashMap<CString, CString>,
+//! ) -> Result<(Vec<openvpn_plugin::types::OpenVpnPluginEvent>, Handle), ::std::io::Error> {
 //!     // Listen to only the `Up` event, which will be fired when a tunnel has been established.
 //!     let events = vec![OpenVpnPluginEvent::Up];
 //!     // Create the handle instance.
@@ -53,16 +53,16 @@
 //!     Ok((events, handle))
 //! }
 //!
-//! pub fn openvpn_close(_handle: Handle) {
+//! pub fn openvpn_close(handle: Handle) {
 //!     println!("Plugin is closing down");
 //! }
 //!
 //! fn openvpn_event(
-//!     _event: openvpn_plugin::types::OpenVpnPluginEvent,
-//!     _args: &[CString],
-//!     _env: &HashMap<CString, CString>,
-//!     _handle: &mut Handle,
-//! ) -> Result<SuccessType, ()> {
+//!     event: openvpn_plugin::types::OpenVpnPluginEvent,
+//!     args: &[CString],
+//!     env: &HashMap<CString, CString>,
+//!     handle: &mut Handle,
+//! ) -> Result<SuccessType, ::std::io::Error> {
 //!     /* Process the event */
 //!
 //!     // If the processing worked fine and/or the request the callback represents should be
@@ -119,7 +119,7 @@ pub mod types;
 /// fn foo_open(
 ///     args: &[CString],
 ///     env: &HashMap<CString, CString>
-/// ) -> Result<(Vec<types::OpenVpnPluginEvent>, $handle_ty), _>
+/// ) -> Result<(Vec<types::OpenVpnPluginEvent>, $handle_ty), Error>
 /// ```
 ///
 /// With `foo_open` substituted for the function name of your liking and `$handle_ty` substituted
@@ -132,9 +132,9 @@ pub mod types;
 /// with the events it wants to register for and the handle instance that the plugin can use to
 /// keep state (See further down for more on the handle).
 ///
-/// The type of the error returned from this function does not matter, as long as it implements
+/// The type of the error in the result from this function does not matter, as long as it implements
 /// `std::error::Error`. Any error returned is being logged with `log_error()`, and then
-/// `openvpn_plugin` returns `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN, which indicates that the plugin
+/// `OPENVPN_PLUGIN_FUNC_ERROR` is returned to OpenVPN, which indicates that the plugin
 /// failed to load and OpenVPN will abort and exit.
 ///
 /// The `openvpn_plugin::ffi::parse::{string_array_utf8, env_utf8}` functions can be used to try
@@ -164,7 +164,7 @@ pub mod types;
 ///     args: &[CString],
 ///     env: &HashMap<CString, CString>,
 ///     handle: &mut $handle_ty,
-/// ) -> Result<types::SuccessType, _>
+/// ) -> Result<types::SuccessType, Error>
 /// ```
 ///
 /// This function is being called by OpenVPN each time one of the events that `$open_fn` registered
@@ -173,9 +173,9 @@ pub mod types;
 ///
 /// The first argument, `OpenVpnPluginEvent`, will tell which event that is happening.
 ///
-/// The type of the error returned from this function does not matter, as long as it implements
+/// The type of the error in the result from this function does not matter, as long as it implements
 /// `std::error::Error`. Any error returned is being logged with `log_error()`, and then
-/// `openvpn_plugin` returns `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN, which indicates different
+/// `OPENVPN_PLUGIN_FUNC_ERROR` is returned to OpenVPN, which indicates different
 /// things on different events. In the case of an authentication request or TLS key verification it
 /// means that the request is denied and the connection is aborted.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub mod types;
 /// See the top level library documentation and the included `debug-plugin` crate for examples on
 /// how to use this macro.
 ///
+///
 /// ## `$open_fn` - The plugin load callback
 ///
 /// Should be a function with the following signature:
@@ -131,12 +132,14 @@ pub mod types;
 /// with the events it wants to register for and the handle instance that the plugin can use to
 /// keep state (See further down for more on the handle).
 ///
-/// The type of the error returned from this function does not matter. Any error makes
-/// `openvpn_plugin` return `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN, which indicates that the plugin
+/// The type of the error returned from this function does not matter, as long as it implements
+/// `std::error::Error`. Any error returned is being logged with `log_error()`, and then
+/// `openvpn_plugin` returns `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN, which indicates that the plugin
 /// failed to load and OpenVPN will abort and exit.
 ///
 /// The `openvpn_plugin::ffi::parse::{string_array_utf8, env_utf8}` functions can be used to try
 /// to convert the arguments and environment into Rust `String`s.
+///
 ///
 /// ## `$close_fn` - The plugin unload callback
 ///
@@ -149,6 +152,7 @@ pub mod types;
 /// This function is called just before the plugin is unloaded, just before OpenVPN shuts down.
 /// Here the plugin can do any cleaning up that is necessary. Since the handle is passed by value it
 /// will be dropped when this function returns.
+///
 ///
 /// ## `$event_fn` - The event callback function
 ///
@@ -169,10 +173,11 @@ pub mod types;
 ///
 /// The first argument, `OpenVpnPluginEvent`, will tell which event that is happening.
 ///
-/// The type of the error returned from this function does not matter. Any error makes
-/// `openvpn_plugin` return `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN, which indicates different things
-/// on different events. In the case of an authentication request or TLS key verification it means
-/// that the request is denied and the connection is aborted.
+/// The type of the error returned from this function does not matter, as long as it implements
+/// `std::error::Error`. Any error returned is being logged with `log_error()`, and then
+/// `openvpn_plugin` returns `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN, which indicates different
+/// things on different events. In the case of an authentication request or TLS key verification it
+/// means that the request is denied and the connection is aborted.
 ///
 /// ## `$handle_ty` - The handle type
 ///

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,30 @@
+/// Error logging method used by the FFI functions to log if `$open_fn` or `$event_fn` return an
+/// error. This version logs using the `error!` macro of the log crate. Compile without the `log`
+/// feature to make it print to stderr.
+#[cfg(feature = "log")]
+pub fn log_error<E: ::std::error::Error>(error: E) {
+    error!("{}", format_error(error));
+}
+
+/// Error logging method used by the FFI functions to log if `$open_fn` or `$event_fn` return an
+/// error. This version only prints to stderr. Build the crate with the `log` feature to log using
+/// the `error!` macro.
+#[cfg(not(feature = "log"))]
+pub fn log_error<E: ::std::error::Error>(error: E) {
+    use std::io::{self, Write};
+    let error_msg = format!("{}\n", format_error(error));
+
+    let mut stderr = io::stderr();
+    let _ = stderr.write_all(error_msg.as_bytes());
+    let _ = stderr.flush();
+}
+
+fn format_error<E: ::std::error::Error>(error: E) -> String {
+    let mut error_string = format!("Error: {}", error);
+    let mut error_iter = error.cause();
+    while let Some(e) = error_iter {
+        error_string.push_str(&format!("\nCaused by: {}", e));
+        error_iter = e.cause();
+    }
+    error_string
+}


### PR DESCRIPTION
Just throwing away errors without printing or alerting anywhere is very bad. Going to make it very hard to write nice plugins and find the errors they produce. So here I (optionally) depend on the `log` crate and log all errors that the plugin throws up to the FFI functions. If built without the `log` feature the errors will be printed to stdout instead of to the `error!` macro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/3)
<!-- Reviewable:end -->
