### PR TITLE
Allow non error failure, and release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2017-07-20
+### Added
+- `EventResult::Failure` to enable returning `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN without logging
+  it as an error.
+
+### Changed
+- Renamed `SuccessType` to `EventResult`.
+
+## [0.1.0] - 2017-07-19
+### Added
+- Initial code for easily creating OpenVPN plugins in Rust.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openvpn-plugin"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>"]
 description = "A crate allowing easy creation of OpenVPN plugins in Rust"
 keywords = ["openvpn", "vpn", "plugin", "ffi", "cdylib"]

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -12,7 +12,7 @@
 #[macro_use]
 extern crate openvpn_plugin;
 
-use openvpn_plugin::types::{OpenVpnPluginEvent, SuccessType};
+use openvpn_plugin::types::{OpenVpnPluginEvent, EventResult};
 use std::collections::HashMap;
 use std::ffi::CString;
 
@@ -61,12 +61,12 @@ fn openvpn_event(
     args: &[CString],
     env: &HashMap<CString, CString>,
     _handle: &mut (),
-) -> Result<SuccessType, ::std::io::Error> {
+) -> Result<EventResult, ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: event called:\n\tevent: {:?}\n\targs: {:?}\n\tenv: {:?}",
         event,
         args,
         env
     );
-    Ok(SuccessType::Success)
+    Ok(EventResult::Success)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,20 +74,30 @@ pub fn events_to_bitmask(events: &[OpenVpnPluginEvent]) -> c_int {
 }
 
 
-/// Enum representing the two ways an OpenVPN plugin can return successfully from an event callback.
+/// Enum representing the results an OpenVPN plugin can return from an event callback.
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum SuccessType {
-    /// Indicates the plugin marks the event as a success. This means an auth is approved or
+pub enum EventResult {
+    /// Will return `OPENVPN_PLUGIN_FUNC_SUCCESS` to OpenVPN.
+    /// Indicates that the plugin marks the event as a success. This means an auth is approved or
     /// similar, depending on which type of event.
     Success,
 
+    /// Will return `OPENVPN_PLUGIN_FUNC_DEFERRED` to OpenVPN.
     /// WARNING: Can only be returned from the `OpenVpnPluginEvent::AuthUserPassVerify`
     /// (`OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY`) event. No other events may return this variant.
     /// Returning this tells OpenVPN to continue its normal work and that the decision on if the
     /// authentication is accepted or not will be delivered later, via writing to the path under
     /// the `auth_control_file` environment variable.
     Deferred,
+
+    /// Will return `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN.
+    /// Both returning `Ok(EventResult::Failure)` and `Err(e)` from a callback will result in
+    /// `OPENVPN_PLUGIN_FUNC_ERROR` being returned to OpenVPN. The difference being that an `Err(e)`
+    /// will also log the error `e`. This variant is intended for when the plugin did not encounter
+    /// an error, but the event is a failure or is to be declined. Intended to be used to decline an
+    /// authentication request and similar.
+    Failure,
 }
 
 


### PR DESCRIPTION
I realized there are legitimate scenarios where a plugin wants to return `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN without it being an actual error. This includes authentication requests that the plugin wants to deny. In those scenarios the plugin probably don't want every denied auth in the error log, or at least they want the possibility to control such logging for themselves.

Since I changed the name of an enum this is a breaking change and I have to bump to 0.2.0.

I also added a proper changelog. There is an awesome site at http://keepachangelog.com/ having a standard for how to write changelogs and tips for how to make the changelog great. So I used their template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/4)
<!-- Reviewable:end -->
