### PR TITLE
Use workaround to enable derive in "serde" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_script:
 script:
   - cargo build
   - cargo test
-  - cargo build --features "serialize log"
-  - cargo test --features "serialize log"
+  - cargo build --features "serde log"
+  - cargo test --features "serde log"
   - cd debug-plugin; cargo build
 
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,6 @@ categories = ["api-bindings", "external-ffi-bindings", "network-programming"]
 repository = "https://github.com/mullvad/openvpn-plugin-rs"
 license = "MIT/Apache-2.0"
 
-[features]
-default = []
-serialize = ["serde", "serde_derive"]
-
 [dependencies]
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 log = { version = "0.3", optional = true }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,11 +45,11 @@ install:
 
 # This is the "test phase", tweak it as you see fit
 test_script:
-  - cargo build --target %TARGET%
-  - cargo test --target %TARGET%
-  - cargo build --features "serde log" --target %TARGET%
-  - cargo test --features "serde log" --target %TARGET%
-  - cd debug-plugin && cargo build --target %TARGET%
+  - cargo build
+  - cargo test
+  - cargo build --features "serde log"
+  - cargo test --features "serde log"
+  - cd debug-plugin && cargo build
 
 # Cache build binaries for faster builds next time
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,8 +47,8 @@ install:
 test_script:
   - cargo build --target %TARGET%
   - cargo test --target %TARGET%
-  - cargo build --features "serialize log" --target %TARGET%
-  - cargo test --features "serialize log" --target %TARGET%
+  - cargo build --features "serde log" --target %TARGET%
+  - cargo test --features "serde log" --target %TARGET%
   - cd debug-plugin && cargo build --target %TARGET%
 
 # Cache build binaries for faster builds next time

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ where
     );
 
     let result = panic::catch_unwind(|| {
-        let handle: &mut H = unsafe { &mut *((*args).handle as *mut H) };
+        let handle: &mut H = &mut *((*args).handle as *mut H);
         event_fn(event, parsed_args, parsed_env, handle)
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,11 +99,9 @@
 //! [`OPENVPN_PLUGIN_FUNC_ERROR`]: ffi/constant.OPENVPN_PLUGIN_FUNC_ERROR.html
 //! [`catch_unwind`]: https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
 
-#[cfg(feature = "serialize")]
+#[cfg(feature = "serde")]
+#[cfg_attr(feature = "serde", macro_use)]
 extern crate serde;
-#[cfg_attr(feature = "serialize", macro_use)]
-#[cfg(feature = "serialize")]
-extern crate serde_derive;
 
 #[cfg_attr(feature = "log", macro_use)]
 #[cfg(feature = "log")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,7 +32,7 @@ impl error::Error for InvalidEnumVariant {
 
 /// Enum whose variants correspond to the `OPENVPN_PLUGIN_*` event constants.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OpenVpnPluginEvent {
     Up = 0,
     Down = 1,
@@ -75,7 +75,7 @@ pub fn events_to_bitmask(events: &[OpenVpnPluginEvent]) -> c_int {
 
 
 /// Enum representing the results an OpenVPN plugin can return from an event callback.
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum EventResult {
     /// Will return `OPENVPN_PLUGIN_FUNC_SUCCESS` to OpenVPN.


### PR DESCRIPTION
The macro derive* stuff is located inside `serde_derive`. But it's a hassle to have to depend on both `serde` and `serde_derive` and then define a custom feature that enables them both. To fix this the `serde` developers have made the macro stuff available directly through the main `serde` crate if it's built with the `derive` feature. So here I apply this fix to make our dependency to serialization nicer.

*: Serde provides nice automatic serialization/deserialization via `#[derive(Serialize, Deserialize)]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/6)
<!-- Reviewable:end -->
