### PR TITLE
Restructure and catch panics

### DIFF
--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -12,7 +12,7 @@
 #[macro_use]
 extern crate openvpn_plugin;
 
-use openvpn_plugin::types::{OpenVpnPluginEvent, EventResult};
+use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};
 use std::collections::HashMap;
 use std::ffi::CString;
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -12,7 +12,8 @@ use std::os::raw::c_int;
 pub mod parse;
 
 /// Rust representations of the C structs sent in and expected back by OpenVPN.
-pub mod structs;
+mod structs;
+pub use self::structs::*;
 
 // Return values. Returned from the plugin to OpenVPN to indicate success or failure. Can also
 // Accept (success) or decline (error) operations, such as incoming client connection attempts.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,8 @@ pub mod ffi;
 pub mod types;
 
 /// Functions for logging errors that occur in plugins.
-pub mod logging;
+#[macro_use]
+mod logging;
 
 
 /// The main part of this crate. The macro generates the public FFI functions that OpenVPN looks
@@ -248,7 +249,7 @@ macro_rules! try_or_return_error {
         match $result {
             Ok(result) => result,
             Err(e) => {
-                logging::log_error(Error::new($error_msg, e));
+                log_error!(Error::new($error_msg, e));
                 return ffi::OPENVPN_PLUGIN_FUNC_ERROR;
             }
         };
@@ -292,11 +293,11 @@ where
             ffi::OPENVPN_PLUGIN_FUNC_SUCCESS
         }
         Ok(Err(e)) => {
-            logging::log_error(e);
+            log_error!(e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
         Err(e) => {
-            logging::log_panic("plugin open", e);
+            log_panic!("plugin open", e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
     }
@@ -317,7 +318,7 @@ where
     // handle object to be properly deallocated when `$close_fn` returns.
     let handle = *unsafe { Box::from_raw(handle as *mut H) };
     if let Err(e) = panic::catch_unwind(|| close_fn(handle)) {
-        logging::log_panic("plugin close", e);
+        log_panic!("plugin close", e);
     }
 }
 
@@ -360,11 +361,11 @@ where
         Ok(Ok(EventResult::Deferred)) => ffi::OPENVPN_PLUGIN_FUNC_DEFERRED,
         Ok(Ok(EventResult::Failure)) => ffi::OPENVPN_PLUGIN_FUNC_ERROR,
         Ok(Err(e)) => {
-            logging::log_error(e);
+            log_error!(e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
         Err(e) => {
-            logging::log_panic("plugin func", e);
+            log_panic!("plugin func", e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -2,22 +2,46 @@
 /// error. This version logs using the `error!` macro of the log crate. Compile without the `log`
 /// feature to make it print to stderr.
 #[cfg(feature = "log")]
-pub fn log_error<E: ::std::error::Error>(error: E) {
-    error!("{}", format_error(error));
+mod implementation {
+    use std::any::Any;
+
+    pub fn log_error<E: ::std::error::Error>(error: E) {
+        error!("{}", super::format_error(error));
+    }
+
+    pub fn log_panic(source: &str, panic_payload: Box<Any + Send + 'static>) {
+        let panic_msg = panic_payload.downcast_ref::<&str>().unwrap_or(&"");
+        error!("Panic in the {} callback: {:?}", source, panic_msg);
+    }
 }
 
 /// Error logging method used by the FFI functions to log if `$open_fn` or `$event_fn` return an
 /// error. This version only prints to stderr. Build the crate with the `log` feature to log using
 /// the `error!` macro.
 #[cfg(not(feature = "log"))]
-pub fn log_error<E: ::std::error::Error>(error: E) {
+mod implementation {
+    use std::any::Any;
     use std::io::{self, Write};
-    let error_msg = format!("{}\n", format_error(error));
 
-    let mut stderr = io::stderr();
-    let _ = stderr.write_all(error_msg.as_bytes());
-    let _ = stderr.flush();
+    pub fn log_error<E: ::std::error::Error>(error: E) {
+        let error_msg = format!("{}\n", super::format_error(error));
+
+        let mut stderr = io::stderr();
+        let _ = stderr.write_all(error_msg.as_bytes());
+        let _ = stderr.flush();
+    }
+
+    pub fn log_panic(source: &str, panic_payload: Box<Any + Send + 'static>) {
+        let panic_msg = panic_payload.downcast_ref::<&str>().unwrap_or(&"");
+        let msg = format!("Panic in the {} callback: {:?}", source, panic_msg);
+
+        let mut stderr = io::stderr();
+        let _ = stderr.write_all(msg.as_bytes());
+        let _ = stderr.flush();
+    }
 }
+
+pub use self::implementation::*;
 
 fn format_error<E: ::std::error::Error>(error: E) -> String {
     let mut error_string = format!("Error: {}", error);


### PR DESCRIPTION
I recently learned/discovered that unwinding a panic from Rust into C is undefined behavior and very bad. This could happen in this crate if any of the `.expect(...)` stuff had an error or if the callbacks to the user using this library panicked.

I fixed this by first splitting out all the work in the three plugin functions to separate functions. This made the actual `openvpn_plugin!` macro much simpler and actually possible to see all of it without scrolling basically :) This would reduce the amount of code the plugin would inject into the caller, instead having all that code always present in this crate instead.

Then I wrapped the calls to the callbacks in `::std::panic::catch_unwind()` which allows us to stop panic unwinding, log it and return a proper error type to OpenVPN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/7)
<!-- Reviewable:end -->
