### PR TITLE
Give ownership to callbacks, improve docs, fick lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Categories each change fall into
+
+* **Added**: for new features.
+* **Changed**: for changes in existing functionality.
+* **Deprecated**: for soon-to-be removed features.
+* **Removed**: for now removed features.
+* **Fixed**: for any bug fixes.
+* **Security**: in case of vulnerabilities.
+
+
 ## [Unreleased]
+### Fixed
+- Catch panics from `$open_fn`, `$close_fn` and `$event_fn` instead of unwinding back into C.
+- Correctly handle errors in argument and environment parsing, to not panic unwind into C.
+
+### Changed
+- Give argument and environment variables by ownership to callbacks instead of just borrowing.
+- Make documentation code compile as part of tests, to verify it works.
+
 
 ## [0.2.0] - 2017-07-20
 ### Added
@@ -13,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Renamed `SuccessType` to `EventResult`.
+
 
 ## [0.1.0] - 2017-07-19
 ### Added

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -39,8 +39,8 @@ pub static INTERESTING_EVENTS: &[OpenVpnPluginEvent] = &[
 openvpn_plugin!(::openvpn_open, ::lol::openvpn_close, ::openvpn_event, ());
 
 fn openvpn_open(
-    args: &[CString],
-    env: &HashMap<CString, CString>,
+    args: Vec<CString>,
+    env: HashMap<CString, CString>,
 ) -> Result<(Vec<OpenVpnPluginEvent>, ()), ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: open called:\n\targs: {:?}\n\tenv: {:?}",
@@ -58,8 +58,8 @@ mod lol {
 
 fn openvpn_event(
     event: OpenVpnPluginEvent,
-    args: &[CString],
-    env: &HashMap<CString, CString>,
+    args: Vec<CString>,
+    env: HashMap<CString, CString>,
     _handle: &mut (),
 ) -> Result<EventResult, ::std::io::Error> {
     println!(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,12 @@
+# Activation of features, almost objectively better ;)
+reorder_imports = true
+reorder_imported_names = true
+reorder_imports_in_group = true
+use_try_shorthand = true
+condense_wildcard_suffices = true
+normalize_comments = true
+wrap_comments = true
+
+# Heavily subjective style choices
+comment_width = 100
+take_source_hints = true

--- a/src/ffi/parse.rs
+++ b/src/ffi/parse.rs
@@ -90,8 +90,8 @@ pub unsafe fn env(envptr: *const *const c_char) -> Result<HashMap<CString, CStri
         let string_bytes = string.as_bytes();
         let equal_index = string_bytes
             .iter()
-            .position(|&c| c == '=' as u8)
-            .ok_or(ParseError::NoEqual(string.clone()))?;
+            .position(|&c| c == b'=')
+            .ok_or_else(|| ParseError::NoEqual(string.clone()))?;
 
         // It's safe to unwrap since CString guarantees no null bytes.
         let key = CString::new(&string_bytes[..equal_index]).unwrap();

--- a/src/ffi/parse.rs
+++ b/src/ffi/parse.rs
@@ -7,11 +7,11 @@
 // except according to those terms.
 
 use std::collections::HashMap;
+use std::error::Error;
 use std::ffi::{CStr, CString};
+use std::fmt;
 use std::os::raw::c_char;
 use std::str::Utf8Error;
-use std::fmt;
-use std::error::Error;
 
 /// Error type returned by the ffi parsing functions if the input data is invalid in some way.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,21 +23,23 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies]
-//! openvpn-plugin = "0.1"
+//! openvpn-plugin = "x.y"
 //! ```
 //!
-//! Import the crate, including macros, in your crate root (`lib.rs`):
-//!
-//! ```rust,ignore
-//! #[macro_use] extern crate openvpn_plugin;
-//! ```
-//!
-//! Also in your crate root (`lib.rs`) define your handle type, the three callback functions and
-//! call the `openvpn_plugin!` macro to generate the corresponding FFI bindings.
+//! In your crate root (`lib.rs`) define your handle type, the three callback functions and
+//! call the [`openvpn_plugin!`] macro to generate the corresponding FFI bindings.
 //! More details on the handle and the callback functions can be found in the documentation for the
-//! [`openvpn_plugin!`](macro.openvpn_plugin.html) macro.
+//! [`openvpn_plugin!`] macro.
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! #[macro_use]
+//! extern crate openvpn_plugin;
+//!
+//! use std::collections::HashMap;
+//! use std::ffi::CString;
+//! use std::io::Error;
+//! use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};
+//!
 //! pub struct Handle {
 //!     // Fields needed for the plugin to keep state between callbacks
 //! }
@@ -45,7 +47,7 @@
 //! fn openvpn_open(
 //!     args: &[CString],
 //!     env: &HashMap<CString, CString>,
-//! ) -> Result<(Vec<openvpn_plugin::types::OpenVpnPluginEvent>, Handle), ::std::io::Error> {
+//! ) -> Result<(Vec<OpenVpnPluginEvent>, Handle), Error> {
 //!     // Listen to only the `Up` event, which will be fired when a tunnel has been established.
 //!     let events = vec![OpenVpnPluginEvent::Up];
 //!     // Create the handle instance.
@@ -53,26 +55,49 @@
 //!     Ok((events, handle))
 //! }
 //!
-//! pub fn openvpn_close(handle: Handle) {
+//! fn openvpn_close(handle: Handle) {
 //!     println!("Plugin is closing down");
 //! }
 //!
 //! fn openvpn_event(
-//!     event: openvpn_plugin::types::OpenVpnPluginEvent,
+//!     event: OpenVpnPluginEvent,
 //!     args: &[CString],
 //!     env: &HashMap<CString, CString>,
 //!     handle: &mut Handle,
-//! ) -> Result<EventResult, ::std::io::Error> {
+//! ) -> Result<EventResult, Error> {
 //!     /* Process the event */
 //!
 //!     // If the processing worked fine and/or the request the callback represents should be
-//!     // accepted, return `EventResult::Success`. See docs on this enum for more info.
+//!     // accepted, return EventResult::Success. See EventResult docs for more info.
 //!     Ok(EventResult::Success)
 //! }
 //!
 //! openvpn_plugin!(::openvpn_open, ::openvpn_close, ::openvpn_event, Handle);
+//! # fn main() {}
 //! ```
 //!
+//! ## Panic handling
+//!
+//! C cannot handle Rust panic unwinding and thus it is not good practice to let Rust panic when
+//! called from C. Because of this all calls from this crate to the callbacks given to
+//! [`openvpn_plugin!`] \(`$open_fn`, `$close_fn` and `$event_fn`) are wrapped by
+//! [`catch_unwind`].
+//!
+//! If [`catch_unwind`] captures a panic it will log it and then return [`OPENVPN_PLUGIN_FUNC_ERROR`]
+//! to OpenVPN.
+//!
+//! Note that this will only work for unwinding panics, not with `panic=abort`.
+//!
+//! ## Logging
+//!
+//! Any errors returned from the user defined callbacks or panics that happens anywhere in Rust is
+//! logged by this crate before control is returned to OpenVPN. By default logging happens to
+//! stderr. To activate logging with the `error!` macro in the `log` crate, build this crate with
+// the `log` feature.
+//!
+//! [`openvpn_plugin!`]: macro.openvpn_plugin.html
+//! [`OPENVPN_PLUGIN_FUNC_ERROR`]: ffi/constant.OPENVPN_PLUGIN_FUNC_ERROR.html
+//! [`catch_unwind`]: https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
 
 #[cfg(feature = "serialize")]
 extern crate serde;
@@ -127,15 +152,29 @@ mod logging;
 ///
 /// Should be a function with the following signature:
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # use openvpn_plugin::types::OpenVpnPluginEvent;
+/// # use std::ffi::CString;
+/// # use std::collections::HashMap;
+/// # struct Handle {}
+/// # struct Error {}
 /// fn foo_open(
 ///     args: &[CString],
 ///     env: &HashMap<CString, CString>
-/// ) -> Result<(Vec<types::OpenVpnPluginEvent>, $handle_ty), Error>
+/// ) -> Result<(Vec<OpenVpnPluginEvent>, Handle), Error> {
+///     /// ...
+/// #    unimplemented!();
+/// }
+/// # fn main() {}
 /// ```
 ///
-/// With `foo_open` substituted for the function name of your liking and `$handle_ty` substituted
-/// with the handle type you pass.
+/// With `foo_open` substituted for a function name of your liking and `Handle` being the
+/// `$handle_ty` handle type you pass.
+///
+/// The type of the error in the result from this function does not matter, as long as it implements
+/// `std::error::Error`. Any error returned is logged and then [`OPENVPN_PLUGIN_FUNC_ERROR`]
+/// is returned to OpenVPN, which indicates that the plugin failed to load and OpenVPN will abort
+/// and exit.
 ///
 /// This function will be called by OpenVPN when the plugin is loaded, just as OpenVPN starts.
 ///
@@ -143,11 +182,6 @@ mod logging;
 /// OpenVPN environment. If the plugin deems the open operation successful it should return a vector
 /// with the events it wants to register for and the handle instance that the plugin can use to
 /// keep state (See further down for more on the handle).
-///
-/// The type of the error in the result from this function does not matter, as long as it implements
-/// `std::error::Error`. Any error returned is being logged with `log_error()`, and then
-/// `OPENVPN_PLUGIN_FUNC_ERROR` is returned to OpenVPN, which indicates that the plugin
-/// failed to load and OpenVPN will abort and exit.
 ///
 /// The `openvpn_plugin::ffi::parse::{string_array_utf8, env_utf8}` functions can be used to try
 /// to convert the arguments and environment into Rust `String`s.
@@ -157,9 +191,17 @@ mod logging;
 ///
 /// Should be a function with the following signature:
 ///
-/// ```rust,ignore
-/// fn foo_close(handle: $handle_ty)
+/// ```rust,no_run
+/// # struct Handle {}
+/// fn foo_close(handle: Handle) {
+///     /// ...
+/// #    unimplemented!();
+/// }
+/// # fn main() {}
 /// ```
+///
+/// With `foo_close` substituted for a function name of your liking and `Handle` being the
+/// `$handle_ty` handle type you pass.
 ///
 /// This function is called just before the plugin is unloaded, just before OpenVPN shuts down.
 /// Here the plugin can do any cleaning up that is necessary. Since the handle is passed by value it
@@ -170,26 +212,39 @@ mod logging;
 ///
 /// Should be a function with the following signature:
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};
+/// # use std::ffi::CString;
+/// # use std::collections::HashMap;
+/// # struct Handle {}
+/// # struct Error {}
 /// fn foo_event(
-///     event: types::OpenVpnPluginEvent,
+///     event: OpenVpnPluginEvent,
 ///     args: &[CString],
 ///     env: &HashMap<CString, CString>,
-///     handle: &mut $handle_ty,
-/// ) -> Result<types::EventResult, Error>
+///     handle: &mut Handle,
+/// ) -> Result<EventResult, Error> {
+///     /// ...
+/// #    unimplemented!();
+/// }
+/// # fn main() {}
 /// ```
+///
+/// With `foo_event` substituted for a function name of your liking and `Handle` being the
+/// `$handle_ty` handle type you pass.
+///
+/// The type of the error in the result from this function does not matter, as long as it implements
+/// `std::error::Error`. Any error returned is logged and then [`OPENVPN_PLUGIN_FUNC_ERROR`]
+/// is returned to OpenVPN. [`OPENVPN_PLUGIN_FUNC_ERROR`] indicates different things on different
+/// events. In the case of an authentication request or TLS key verification it means that the
+/// request is denied and the connection is aborted.
 ///
 /// This function is being called by OpenVPN each time one of the events that `$open_fn` registered
 /// for happens. This can for example be that a tunnel is established or that a client wants to
 /// authenticate.
 ///
-/// The first argument, `OpenVpnPluginEvent`, will tell which event that is happening.
+/// The first argument, [`OpenVpnPluginEvent`], will tell which event that is happening.
 ///
-/// The type of the error in the result from this function does not matter, as long as it implements
-/// `std::error::Error`. Any error returned is being logged with `log_error()`, and then
-/// `OPENVPN_PLUGIN_FUNC_ERROR` is returned to OpenVPN, which indicates different
-/// things on different events. In the case of an authentication request or TLS key verification it
-/// means that the request is denied and the connection is aborted.
 ///
 /// ## `$handle_ty` - The handle type
 ///
@@ -197,6 +252,11 @@ mod logging;
 /// entire runtime of the plugin. The handle is passed to every subsequent callback and this is the
 /// way that the plugin is supposed to keep state between each callback.
 ///
+/// The handle instance is being dropped upon return from the `$close_fn` function just as the
+/// plugin is being unloaded.
+///
+/// [`OpenVpnPluginEvent`]: types/enum.OpenVpnPluginEvent.html
+/// [`OPENVPN_PLUGIN_FUNC_ERROR`]: ffi/constant.OPENVPN_PLUGIN_FUNC_ERROR.html
 #[macro_export]
 macro_rules! openvpn_plugin {
     ($open_fn:path, $close_fn:path, $event_fn:path, $handle_ty:ty) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,8 +79,8 @@ pub fn events_to_bitmask(events: &[OpenVpnPluginEvent]) -> c_int {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum EventResult {
     /// Will return `OPENVPN_PLUGIN_FUNC_SUCCESS` to OpenVPN.
-    /// Indicates that the plugin marks the event as a success. This means an auth is approved or
-    /// similar, depending on which type of event.
+    /// Indicates that the plugin marks the event as a success. This means an auth is approved
+    /// or similar, depending on which type of event.
     Success,
 
     /// Will return `OPENVPN_PLUGIN_FUNC_DEFERRED` to OpenVPN.
@@ -93,10 +93,10 @@ pub enum EventResult {
 
     /// Will return `OPENVPN_PLUGIN_FUNC_ERROR` to OpenVPN.
     /// Both returning `Ok(EventResult::Failure)` and `Err(e)` from a callback will result in
-    /// `OPENVPN_PLUGIN_FUNC_ERROR` being returned to OpenVPN. The difference being that an `Err(e)`
-    /// will also log the error `e`. This variant is intended for when the plugin did not encounter
-    /// an error, but the event is a failure or is to be declined. Intended to be used to decline an
-    /// authentication request and similar.
+    /// `OPENVPN_PLUGIN_FUNC_ERROR` being returned to OpenVPN. The difference being that an
+    /// `Err(e)` will also log the error `e`. This variant is intended for when the plugin did
+    /// not encounter an error, but the event is a failure or is to be declined. Intended to be
+    /// used to decline an authentication request and similar.
     Failure,
 }
 


### PR DESCRIPTION
This PR is a bit spread out. It might be easiest to view per commit.

1. Just some formatting

2. Improve documentation. Now `rustdoc` warn in the compiled documentation if the examples in the docs were not run on doc compilation. To warn that the code in the docs might not work. So I changed my examples from `rust,ignore` to `rust,no_run`. They are not designed to be run, but now they can at least be compiled. To achieve this I had to add extra code that is invisible, but make it compile. In the doc comments one can use:
```
# <code here>
```
for code that will be there when compiling/verifying the test, but it will not be visible in the docs. Great for setting up stuff needed for it to compile, but that is irrelevant for what you want to communicate in the doc itself.

3. We passed `args` and `env` to callbacks by lending them. But we did not use them for anything after the callback, so why not give by ownership. If the plugin need to keep the allocated data for some reason they can now do that. With the borrowed version they had to clone the args and env they wanted to keep.

4. I ran the linter `clippy` on the repo. It found a fair amount of things worth fixing. I'll write comments next to that code to describe it more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/8)
<!-- Reviewable:end -->
