### PR TITLE
Adapt this plugin to the new AUTH_FAILED event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
   - beta
   - nightly
   # Oldest supported version
-  - 1.31.0
+  - 1.40.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Upgrade to Rust 2018. New required minimum Rust version is 1.31.0.
+- Upgrade to Rust 2018. New required minimum Rust version is 1.40.0 (#[non_exhaustive]).
 - Rename `OpenVpnPluginEvent` to `EventType`.
 - Rename `EventType::from_int` to `from_repr` and make it return `None` on failure instead of error.
 - Make `types` module private and re-export `EventType` plus `EventResult` at crate root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Add `EventType::AuthFailed` behind a feature (`auth-failed-event`). Allows the plugin to process
+  the [Mullvad VPN specific] event in the fork.
+
+[Mullvad VPN specific]: https://github.com/mullvad/openvpn
+
 ### Changed
 - Upgrade to Rust 2018. New required minimum Rust version is 1.40.0 (#[non_exhaustive]).
 - Rename `OpenVpnPluginEvent` to `EventType`.
@@ -22,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make `types` module private and re-export `EventType` plus `EventResult` at crate root.
 - Modernize the error types. Remove `Error::description` implementation (in favor of just using
   the `Display` implementation) and change `Error::cause` into `Error::source`.
+- Make `EventType` a `#[non_exhaustive]` enum to allow conditionally adding variants with features.
 
 ### Removed
 - The `EventType::N` variant. It is not a real event.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ repository = "https://github.com/mullvad/openvpn-plugin-rs"
 license = "MIT/Apache-2.0"
 edition = "2018"
 
+[features]
+# Adds `EventType::AuthFailed`. This plugin event is specific to the Mullvad VPN fork of OpenVPN,
+# which is useful to anyone who want to detect client authentication failures in an OpenVPN plugin.
+# This event will never happen on standard upstream OpenVPN.
+# https://github.com/mullvad/openvpn
+auth-failed-event = []
+
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 log = { version = "0.4", optional = true }

--- a/debug-plugin/Cargo.toml
+++ b/debug-plugin/Cargo.toml
@@ -8,5 +8,8 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+auth-failed-event = ["openvpn-plugin/auth-failed-event"]
+
 [dependencies]
 openvpn-plugin = { path = "../", features = ["log", "serde"] }

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -30,6 +30,8 @@ pub static INTERESTING_EVENTS: &[EventType] = &[
     EventType::TlsFinal,
     EventType::EnablePf,
     EventType::RoutePredown,
+    #[cfg(feature = "auth-failed-event")]
+    EventType::AuthFailed,
 ];
 
 openvpn_plugin::openvpn_plugin!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,7 @@ use derive_try_from_primitive::TryFromPrimitive;
 /// This is a Rust representation of the constants named ´OPENVPN_PLUGIN_*` in `openvpn-plugin.h`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 #[repr(i32)]
 pub enum EventType {
     Up = 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,4 +108,15 @@ mod tests {
         let result = events_to_bitmask(&[EventType::RouteUp, EventType::RoutePredown]);
         assert_eq!((1 << 12) | (1 << 2), result);
     }
+
+    #[test]
+    fn events_max_value() {
+        let auth_failed = EventType::try_from(13);
+        #[cfg(feature = "auth-failed-event")]
+        assert_eq!(auth_failed.unwrap(), EventType::AuthFailed);
+        #[cfg(not(feature = "auth-failed-event"))]
+        assert!(auth_failed.is_none());
+
+        assert!(EventType::try_from(14).is_none());
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,6 +33,8 @@ pub enum EventType {
     TlsFinal = 10,
     EnablePf = 11,
     RoutePredown = 12,
+    #[cfg(feature = "auth-failed-event")]
+    AuthFailed = 13,
 }
 
 /// Translates a collection of `EventType` instances into a bitmask in the format OpenVPN


### PR DESCRIPTION
Companion to https://github.com/mullvad/openvpn/pull/1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/9)
<!-- Reviewable:end -->
