### PR TITLE
Fix clippy errors/warnings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,12 +1,9 @@
 # Activation of features, almost objectively better ;)
-reorder_imports = true
-reorder_imported_names = true
-reorder_imports_in_group = true
 use_try_shorthand = true
-condense_wildcard_suffices = true
+condense_wildcard_suffixes = true
 normalize_comments = true
 wrap_comments = true
 
 # Heavily subjective style choices
 comment_width = 100
-take_source_hints = true
+blank_lines_upper_bound = 2

--- a/src/ffi/parse.rs
+++ b/src/ffi/parse.rs
@@ -120,10 +120,9 @@ mod tests {
 
     #[test]
     fn string_array_null() {
-        assert_eq!(
-            Err(ParseError::NullPtr),
-            unsafe { string_array(ptr::null()) }
-        );
+        assert_eq!(Err(ParseError::NullPtr), unsafe {
+            string_array(ptr::null())
+        });
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@
 //! [`openvpn_plugin!`] \(`$open_fn`, `$close_fn` and `$event_fn`) are wrapped by
 //! [`catch_unwind`].
 //!
-//! If [`catch_unwind`] captures a panic it will log it and then return [`OPENVPN_PLUGIN_FUNC_ERROR`]
-//! to OpenVPN.
+//! If [`catch_unwind`] captures a panic it will log it and then return
+//! [`OPENVPN_PLUGIN_FUNC_ERROR`] to OpenVPN.
 //!
 //! Note that this will only work for unwinding panics, not with `panic=abort`.
 //!
@@ -94,7 +94,6 @@
 //! logged by this crate before control is returned to OpenVPN. By default logging happens to
 //! stderr. To activate logging with the `error!` macro in the `log` crate, build this crate with
 // the `log` feature.
-//!
 //! [`openvpn_plugin!`]: macro.openvpn_plugin.html
 //! [`OPENVPN_PLUGIN_FUNC_ERROR`]: ffi/constant.OPENVPN_PLUGIN_FUNC_ERROR.html
 //! [`catch_unwind`]: https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
@@ -294,7 +293,7 @@ macro_rules! openvpn_plugin {
         ) -> ::std::os::raw::c_int {
             unsafe { $crate::openvpn_plugin_func(args, $event_fn) }
         }
-    }
+    };
 }
 
 
@@ -311,7 +310,7 @@ macro_rules! try_or_return_error {
                 return ffi::OPENVPN_PLUGIN_FUNC_ERROR;
             }
         };
-    }
+    };
 }
 
 
@@ -328,17 +327,14 @@ pub unsafe fn openvpn_plugin_open<H, E, F>(
 where
     E: ::std::error::Error,
     F: panic::RefUnwindSafe,
-    F: Fn(Vec<CString>, HashMap<CString, CString>)
-        -> Result<(Vec<OpenVpnPluginEvent>, H), E>,
+    F: Fn(Vec<CString>, HashMap<CString, CString>) -> Result<(Vec<OpenVpnPluginEvent>, H), E>,
 {
     let parsed_args = try_or_return_error!(
         ffi::parse::string_array((*args).argv),
         "Malformed args from OpenVPN"
     );
-    let parsed_env = try_or_return_error!(
-        ffi::parse::env((*args).envp),
-        "Malformed env from OpenVPN"
-    );
+    let parsed_env =
+        try_or_return_error!(ffi::parse::env((*args).envp), "Malformed env from OpenVPN");
 
     match panic::catch_unwind(|| open_fn(parsed_args, parsed_env)) {
         Ok(Ok((events, handle))) => {
@@ -400,10 +396,8 @@ where
         ffi::parse::string_array((*args).argv),
         "Malformed args from OpenVPN"
     );
-    let parsed_env = try_or_return_error!(
-        ffi::parse::env((*args).envp),
-        "Malformed env from OpenVPN"
-    );
+    let parsed_env =
+        try_or_return_error!(ffi::parse::env((*args).envp), "Malformed env from OpenVPN");
 
     let result = panic::catch_unwind(|| {
         let handle: &mut H = &mut *((*args).handle as *mut H);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ where
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
         Err(e) => {
-            log_panic!("plugin open", e);
+            log_panic!("plugin open", &e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
     }
@@ -372,7 +372,7 @@ where
     // handle object to be properly deallocated when `$close_fn` returns.
     let handle = *Box::from_raw(handle as *mut H);
     if let Err(e) = panic::catch_unwind(|| close_fn(handle)) {
-        log_panic!("plugin close", e);
+        log_panic!("plugin close", &e);
     }
 }
 
@@ -419,7 +419,7 @@ where
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
         Err(e) => {
-            log_panic!("plugin func", e);
+            log_panic!("plugin func", &e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ macro_rules! openvpn_plugin {
         /// Will parse the data from OpenVPN and call the function given as `$open_fn` to the
         /// `openvpn_plugin` macro.
         #[no_mangle]
-        pub extern "C" fn openvpn_plugin_open_v3(
+        pub unsafe extern "C" fn openvpn_plugin_open_v3(
             _version: ::std::os::raw::c_int,
             args: *const $crate::ffi::openvpn_plugin_args_open_in,
             retptr: *mut $crate::ffi::openvpn_plugin_args_open_return,
@@ -277,7 +277,7 @@ macro_rules! openvpn_plugin {
         /// Called by OpenVPN when the plugin is unloaded, just before OpenVPN shuts down.
         /// Will call the function given as `$event_fn` to the `openvpn_plugin` macro.
         #[no_mangle]
-        pub extern "C" fn openvpn_plugin_close_v1(handle: *const ::std::os::raw::c_void) {
+        pub unsafe extern "C" fn openvpn_plugin_close_v1(handle: *const ::std::os::raw::c_void) {
             unsafe { $crate::openvpn_plugin_close(handle, $close_fn) }
         }
 
@@ -287,7 +287,7 @@ macro_rules! openvpn_plugin {
         /// Will parse the data from OpenVPN and call the function given as `$event_fn` to the
         /// `openvpn_plugin` macro.
         #[no_mangle]
-        pub extern "C" fn openvpn_plugin_func_v3(
+        pub unsafe extern "C" fn openvpn_plugin_func_v3(
             _version: ::std::os::raw::c_int,
             args: *const $crate::ffi::openvpn_plugin_args_func_in,
             _retptr: *const $crate::ffi::openvpn_plugin_args_func_return,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,24 +23,16 @@ macro_rules! log_panic {
 #[cfg(not(feature = "log"))]
 macro_rules! log_error {
     ($error:expr) => {{
-        logging::try_write_stderr(&logging::format_error(&$error));
+        eprintln!("{}", &logging::format_error(&$error));
     }};
 }
 
 #[cfg(not(feature = "log"))]
 macro_rules! log_panic {
     ($source:expr, $panic_payload:expr) => {{
-        logging::try_write_stderr(&logging::format_panic($source, $panic_payload));
+        eprintln!("{}", &logging::format_panic($source, $panic_payload));
     }};
 }
-
-#[cfg(not(feature = "log"))]
-pub fn try_write_stderr(msg: &str) {
-    use std::io::{self, Write};
-    let mut stderr = io::stderr();
-    let _ = writeln!(stderr, "{}", msg);
-}
-
 
 pub fn format_error<E: ::std::error::Error>(error: &E) -> String {
     let mut error_string = format!("Error: {}", error);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,14 +7,14 @@ use std::any::Any;
 macro_rules! log_error {
     ($error:expr) => {
         error!("{}", logging::format_error(&$error));
-    }
+    };
 }
 
 #[cfg(feature = "log")]
 macro_rules! log_panic {
     ($source:expr, $panic_payload:expr) => {
         error!("{}", logging::format_panic($source, $panic_payload));
-    }
+    };
 }
 
 /// Error logging method used by the FFI functions to log if `$open_fn` or `$event_fn` return an
@@ -24,14 +24,14 @@ macro_rules! log_panic {
 macro_rules! log_error {
     ($error:expr) => {{
         logging::try_write_stderr(&logging::format_error(&$error));
-    }}
+    }};
 }
 
 #[cfg(not(feature = "log"))]
 macro_rules! log_panic {
     ($source:expr, $panic_payload:expr) => {{
         logging::try_write_stderr(&logging::format_panic($source, $panic_payload));
-    }}
+    }};
 }
 
 #[cfg(not(feature = "log"))]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -38,8 +38,7 @@ macro_rules! log_panic {
 pub fn try_write_stderr(msg: &str) {
     use std::io::{self, Write};
     let mut stderr = io::stderr();
-    let _ = write!(stderr, "{}\n", msg);
-    let _ = stderr.flush();
+    let _ = writeln!(stderr, "{}", msg);
 }
 
 
@@ -53,7 +52,7 @@ pub fn format_error<E: ::std::error::Error>(error: &E) -> String {
     error_string
 }
 
-pub fn format_panic(source: &str, panic_payload: Box<Any + Send + 'static>) -> String {
+pub fn format_panic(source: &str, panic_payload: &Box<Any + Send + 'static>) -> String {
     static NO_MSG: &'static str = "No panic message";
     let panic_msg = panic_payload.downcast_ref::<&str>().unwrap_or(&NO_MSG);
     format!("Panic in the {} callback: {:?}", source, panic_msg)

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,9 +54,7 @@ impl OpenVpnPluginEvent {
     /// Tries to parse an integer from C into a variant of `OpenVpnPluginEvent`.
     pub fn from_int(i: c_int) -> Result<OpenVpnPluginEvent, InvalidEnumVariant> {
         if i >= OpenVpnPluginEvent::Up as c_int && i <= OpenVpnPluginEvent::N as c_int {
-            Ok(unsafe {
-                ::std::mem::transmute_copy::<c_int, OpenVpnPluginEvent>(&i)
-            })
+            Ok(unsafe { ::std::mem::transmute_copy::<c_int, OpenVpnPluginEvent>(&i) })
         } else {
             Err(InvalidEnumVariant(i))
         }


### PR DESCRIPTION
Update `rustfmt.toml` to our latest version and run formatting. Also fix most clippy warnings/errors.

Adding the `unsafe` to the extern functions generated by the macro was the thing triggering me to do this. This is marked as an error by clippy and not just a warning. Since that function indeed dereferences raw pointers, it's wildly unsafe and should be marked as such. The problem is that because it's a macro and the functions generated by it will end up in the user of the library, the users will get the clippy errors and not this library. So now the `debug-plugin` under this repo will get rid of those clippy warnings, and later we will as well in our main product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/10)
<!-- Reviewable:end -->
