### PR TITLE
Enforce handle type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Prepare for Rust 2018. New required minimum Rustc is 1.30.
+
+### Fixed
+- Force the handle type to be the same across all three callback functions in the `openvpn_plugin!`
+  macro.
 
 
 ## [0.3.0] - 2017-10-13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
-log = { version = "0.3", optional = true }
+log = { version = "0.4", optional = true }

--- a/debug-plugin/Cargo.toml
+++ b/debug-plugin/Cargo.toml
@@ -8,4 +8,4 @@ description = "An example/debug OpenVPN plugin. Showing the features of openvpn-
 crate-type = ["cdylib"]
 
 [dependencies]
-openvpn-plugin = { path = "../", features = ["log"] }
+openvpn-plugin = { path = "../", features = ["log", "serde"] }

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -9,7 +9,6 @@
 //! This debug/example OpenVPN plugin listens for almost all events and prints the arguments
 //! for each event callback and returns success in every case.
 
-#[macro_use]
 extern crate openvpn_plugin;
 
 use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};
@@ -36,27 +35,31 @@ pub static INTERESTING_EVENTS: &[OpenVpnPluginEvent] = &[
     // OpenVpnPluginEvent::N,
 ];
 
-openvpn_plugin!(::openvpn_open, ::lol::openvpn_close, ::openvpn_event, ());
+openvpn_plugin::openvpn_plugin!(
+    crate::debug_open,
+    crate::lol::debug_close,
+    crate::debug_event,
+    ()
+);
 
-fn openvpn_open(
+fn debug_open(
     args: Vec<CString>,
     env: HashMap<CString, CString>,
 ) -> Result<(Vec<OpenVpnPluginEvent>, ()), ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: open called:\n\targs: {:?}\n\tenv: {:?}",
-        args,
-        env
+        args, env
     );
     Ok((INTERESTING_EVENTS.to_vec(), ()))
 }
 
 mod lol {
-    pub fn openvpn_close(_handle: ()) {
+    pub fn debug_close(_handle: ()) {
         println!("DEBUG-PLUGIN: close called")
     }
 }
 
-fn openvpn_event(
+fn debug_event(
     event: OpenVpnPluginEvent,
     args: Vec<CString>,
     env: HashMap<CString, CString>,
@@ -64,9 +67,7 @@ fn openvpn_event(
 ) -> Result<EventResult, ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: event called:\n\tevent: {:?}\n\targs: {:?}\n\tenv: {:?}",
-        event,
-        args,
-        env
+        event, args, env
     );
     Ok(EventResult::Success)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,6 @@ pub mod ffi;
 pub mod types;
 
 /// Functions for logging errors that occur in plugins.
-#[macro_use]
 mod logging;
 
 
@@ -306,7 +305,7 @@ macro_rules! try_or_return_error {
         match $result {
             Ok(result) => result,
             Err(e) => {
-                log_error!(Error::new($error_msg, e));
+                logging::log_error(&Error::new($error_msg, e));
                 return ffi::OPENVPN_PLUGIN_FUNC_ERROR;
             }
         };
@@ -343,11 +342,11 @@ where
             ffi::OPENVPN_PLUGIN_FUNC_SUCCESS
         }
         Ok(Err(e)) => {
-            log_error!(e);
+            logging::log_error(&e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
         Err(e) => {
-            log_panic!("plugin open", &e);
+            logging::log_panic("plugin open", &e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
     }
@@ -368,7 +367,7 @@ where
     // handle object to be properly deallocated when `$close_fn` returns.
     let handle = *Box::from_raw(handle as *mut H);
     if let Err(e) = panic::catch_unwind(|| close_fn(handle)) {
-        log_panic!("plugin close", &e);
+        logging::log_panic("plugin close", &e);
     }
 }
 
@@ -409,11 +408,11 @@ where
         Ok(Ok(EventResult::Deferred)) => ffi::OPENVPN_PLUGIN_FUNC_DEFERRED,
         Ok(Ok(EventResult::Failure)) => ffi::OPENVPN_PLUGIN_FUNC_ERROR,
         Ok(Err(e)) => {
-            log_error!(e);
+            logging::log_error(&e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
         Err(e) => {
-            log_panic!("plugin func", &e);
+            logging::log_panic("plugin func", &e);
             ffi::OPENVPN_PLUGIN_FUNC_ERROR
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,14 +270,14 @@ macro_rules! openvpn_plugin {
             args: *const $crate::ffi::openvpn_plugin_args_open_in,
             retptr: *mut $crate::ffi::openvpn_plugin_args_open_return,
         ) -> ::std::os::raw::c_int {
-            unsafe { $crate::openvpn_plugin_open(args, retptr, $open_fn) }
+            unsafe { $crate::openvpn_plugin_open::<$handle_ty, _, _>(args, retptr, $open_fn) }
         }
 
         /// Called by OpenVPN when the plugin is unloaded, just before OpenVPN shuts down.
         /// Will call the function given as `$event_fn` to the `openvpn_plugin` macro.
         #[no_mangle]
         pub unsafe extern "C" fn openvpn_plugin_close_v1(handle: *const ::std::os::raw::c_void) {
-            unsafe { $crate::openvpn_plugin_close(handle, $close_fn) }
+            unsafe { $crate::openvpn_plugin_close::<$handle_ty, _>(handle, $close_fn) }
         }
 
         /// Called by OpenVPN for each `OPENVPN_PLUGIN_*` event that it registered for in
@@ -291,7 +291,7 @@ macro_rules! openvpn_plugin {
             args: *const $crate::ffi::openvpn_plugin_args_func_in,
             _retptr: *const $crate::ffi::openvpn_plugin_args_func_return,
         ) -> ::std::os::raw::c_int {
-            unsafe { $crate::openvpn_plugin_func(args, $event_fn) }
+            unsafe { $crate::openvpn_plugin_func::<$handle_ty, _, _>(args, $event_fn) }
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ extern crate serde;
 #[cfg(feature = "log")]
 extern crate log;
 
-use types::{EventResult, OpenVpnPluginEvent};
+use crate::types::{EventResult, OpenVpnPluginEvent};
 
 use std::collections::HashMap;
 use std::ffi::CString;


### PR DESCRIPTION
I realized the argument `$handle_ty` to the `openvpn_plugin!` macro was completely unused. At first I thought I could remove it. But then I realized that if someone used this and they declared their callbacks like this:
```rust
fn debug_close(handle: Foo) { ... }
fn debug_event(..., handle: &mut Bar) { ... }
```
Then all would compile and look fine and all. Problem would be that our code would cast the void pointer given by OpenVPN to `Foo` when calling close, and to `Bar` when calling event.. Thus it would make seriously invalid memory accesses, all without the user of the library even noticing or ever having to use `unsafe`. This is now fixed by using the `$handle_ty` argument and forcing it as the `H` generic in the callbacks.

After that I realized I could do some more cleanup. Biggest part that I could get rid of all the logging macros and just convert them to functions. Much cleaner with less macros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/11)
<!-- Reviewable:end -->
