### PR TITLE
Improve event type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Prepare for Rust 2018. New required minimum Rustc is 1.30.
+- Rename `OpenVpnPluginEvent` to `EventType`.
+- Rename `EventType::from_int` to `from_repr` and make it return `None` on failure instead of error.
+- Make `types` module private and re-export `EventType` plus `EventResult` at crate root.
+
+### Removed
+- The `EventType::N` variant. It is not a real event.
 
 ### Fixed
 - Force the handle type to be the same across all three callback functions in the `openvpn_plugin!`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT/Apache-2.0"
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 log = { version = "0.4", optional = true }
-enum-repr = "0.1.1"
+derive-try-from-primitive = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ license = "MIT/Apache-2.0"
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 log = { version = "0.4", optional = true }
+enum-repr = "0.1.1"

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -11,28 +11,27 @@
 
 extern crate openvpn_plugin;
 
-use openvpn_plugin::types::{EventResult, OpenVpnPluginEvent};
+use openvpn_plugin::{EventResult, EventType};
 use std::collections::HashMap;
 use std::ffi::CString;
 
 /// The list of OpenVPN events we register for. The list contains all possible events, but some of
 /// them are commented out since they work slightly different, and will not work with the simple
 /// log-and-return-success implementation we have here.
-pub static INTERESTING_EVENTS: &[OpenVpnPluginEvent] = &[
-    OpenVpnPluginEvent::Up,
-    OpenVpnPluginEvent::Down,
-    OpenVpnPluginEvent::RouteUp,
-    OpenVpnPluginEvent::IpChange,
-    // OpenVpnPluginEvent::TlsVerify,
-    // OpenVpnPluginEvent::AuthUserPassVerify,
-    OpenVpnPluginEvent::ClientConnect,
-    OpenVpnPluginEvent::ClientDisconnect,
-    OpenVpnPluginEvent::LearnAddress,
-    OpenVpnPluginEvent::ClientConnectV2,
-    OpenVpnPluginEvent::TlsFinal,
-    OpenVpnPluginEvent::EnablePf,
-    OpenVpnPluginEvent::RoutePredown,
-    // OpenVpnPluginEvent::N,
+pub static INTERESTING_EVENTS: &[EventType] = &[
+    EventType::Up,
+    EventType::Down,
+    EventType::RouteUp,
+    EventType::IpChange,
+    // EventType::TlsVerify,
+    // EventType::AuthUserPassVerify,
+    EventType::ClientConnect,
+    EventType::ClientDisconnect,
+    EventType::LearnAddress,
+    EventType::ClientConnectV2,
+    EventType::TlsFinal,
+    EventType::EnablePf,
+    EventType::RoutePredown,
 ];
 
 openvpn_plugin::openvpn_plugin!(
@@ -45,7 +44,7 @@ openvpn_plugin::openvpn_plugin!(
 fn debug_open(
     args: Vec<CString>,
     env: HashMap<CString, CString>,
-) -> Result<(Vec<OpenVpnPluginEvent>, ()), ::std::io::Error> {
+) -> Result<(Vec<EventType>, ()), ::std::io::Error> {
     println!(
         "DEBUG-PLUGIN: open called:\n\targs: {:?}\n\tenv: {:?}",
         args, env
@@ -60,7 +59,7 @@ mod lol {
 }
 
 fn debug_event(
-    event: OpenVpnPluginEvent,
+    event: EventType,
     args: Vec<CString>,
     env: HashMap<CString, CString>,
     _handle: &mut (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ extern crate serde;
 #[cfg(feature = "log")]
 extern crate log;
 
-extern crate enum_repr;
+extern crate derive_try_from_primitive;
 
 use std::{
     collections::HashMap,
@@ -390,7 +390,7 @@ where
 {
     let event_type = (*args).event_type;
     let event = try_or_return_error!(
-        EventType::from_repr(event_type).ok_or_else(|| InvalidEventType(event_type)),
+        EventType::try_from(event_type).ok_or_else(|| InvalidEventType(event_type)),
         "Invalid event integer"
     );
     let parsed_args = try_or_return_error!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@
 #[cfg_attr(feature = "serde", macro_use)]
 extern crate serde;
 
-#[cfg_attr(feature = "log", macro_use)]
 #[cfg(feature = "log")]
 extern crate log;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,7 +7,7 @@ pub fn log_error(error: &impl Error) {
     let error_msg = format_error(error);
     #[cfg(feature = "log")]
     {
-        error!("{}", error_msg);
+        log::error!("{}", error_msg);
     }
     #[cfg(not(feature = "log"))]
     {
@@ -22,7 +22,7 @@ pub fn log_panic(source: &str, panic_payload: &Box<Any + Send + 'static>) {
 
     #[cfg(feature = "log")]
     {
-        error!("Panic in the {} callback: {:?}", source, panic_msg);
+        log::error!("Panic in the {} callback: {:?}", source, panic_msg);
     }
     #[cfg(not(feature = "log"))]
     {

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,11 +11,14 @@
 
 use std::os::raw::c_int;
 
-use enum_repr::EnumRepr;
+use derive_try_from_primitive::TryFromPrimitive;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, EnumRepr)]
+
+/// All the events that an OpenVPN plugin can register for and get notified about.
+/// This is a Rust representation of the constants named ´OPENVPN_PLUGIN_*` in `openvpn-plugin.h`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[EnumReprType = "c_int"]
+#[repr(i32)]
 pub enum EventType {
     Up = 0,
     Down = 1,

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,31 +9,14 @@
 //! Constants for OpenVPN. Taken from include/openvpn-plugin.h in the OpenVPN repository:
 //! https://github.com/OpenVPN/openvpn/blob/master/include/openvpn-plugin.h.in
 
-use std::error;
-use std::fmt;
 use std::os::raw::c_int;
 
-/// Error thrown when trying to convert from an invalid integer into an `OpenVpnPluginEvent`.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct InvalidEnumVariant(c_int);
+use enum_repr::EnumRepr;
 
-impl fmt::Display for InvalidEnumVariant {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{} is not a valid OPENVPN_PLUGIN_* constant", self.0)
-    }
-}
-
-impl error::Error for InvalidEnumVariant {
-    fn description(&self) -> &str {
-        "Integer does not match any enum variant"
-    }
-}
-
-
-/// Enum whose variants correspond to the `OPENVPN_PLUGIN_*` event constants.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, EnumRepr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum OpenVpnPluginEvent {
+#[EnumReprType = "c_int"]
+pub enum EventType {
     Up = 0,
     Down = 1,
     RouteUp = 2,
@@ -47,23 +30,11 @@ pub enum OpenVpnPluginEvent {
     TlsFinal = 10,
     EnablePf = 11,
     RoutePredown = 12,
-    N = 13,
 }
 
-impl OpenVpnPluginEvent {
-    /// Tries to parse an integer from C into a variant of `OpenVpnPluginEvent`.
-    pub fn from_int(i: c_int) -> Result<OpenVpnPluginEvent, InvalidEnumVariant> {
-        if i >= OpenVpnPluginEvent::Up as c_int && i <= OpenVpnPluginEvent::N as c_int {
-            Ok(unsafe { ::std::mem::transmute_copy::<c_int, OpenVpnPluginEvent>(&i) })
-        } else {
-            Err(InvalidEnumVariant(i))
-        }
-    }
-}
-
-/// Translates a collection of `OpenVpnPluginEvent` instances into a bitmask in the format OpenVPN
+/// Translates a collection of `EventType` instances into a bitmask in the format OpenVPN
 /// expects it in `type_mask`.
-pub fn events_to_bitmask(events: &[OpenVpnPluginEvent]) -> c_int {
+pub fn events_to_bitmask(events: &[EventType]) -> c_int {
     let mut bitmask: c_int = 0;
     for event in events {
         bitmask |= 1 << (*event as i32);
@@ -82,7 +53,7 @@ pub enum EventResult {
     Success,
 
     /// Will return `OPENVPN_PLUGIN_FUNC_DEFERRED` to OpenVPN.
-    /// WARNING: Can only be returned from the `OpenVpnPluginEvent::AuthUserPassVerify`
+    /// WARNING: Can only be returned from the `EventType::AuthUserPassVerify`
     /// (`OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY`) event. No other events may return this variant.
     /// Returning this tells OpenVPN to continue its normal work and that the decision on if the
     /// authentication is accepted or not will be delivered later, via writing to the path under
@@ -104,39 +75,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_int_first() {
-        assert_eq!(OpenVpnPluginEvent::from_int(0), Ok(OpenVpnPluginEvent::Up));
-    }
-
-    #[test]
-    fn from_int_last() {
-        assert_eq!(OpenVpnPluginEvent::from_int(13), Ok(OpenVpnPluginEvent::N));
-    }
-
-    #[test]
-    fn from_int_all_valid() {
-        for i in 0..13 {
-            if OpenVpnPluginEvent::from_int(i).is_err() {
-                panic!("{} not covered", i);
-            }
-        }
-    }
-
-    #[test]
-    fn from_int_negative() {
-        let result = OpenVpnPluginEvent::from_int(-5);
-        assert_eq!(result, Err(InvalidEnumVariant(-5)));
-    }
-
-    #[test]
-    fn from_int_invalid() {
-        let result = OpenVpnPluginEvent::from_int(14);
-        assert_eq!(result, Err(InvalidEnumVariant(14)));
-    }
-
-    #[test]
     fn event_enum_to_str() {
-        let result = format!("{:?}", OpenVpnPluginEvent::Up);
+        let result = format!("{:?}", EventType::Up);
         assert_eq!("Up", result);
     }
 
@@ -148,19 +88,19 @@ mod tests {
 
     #[test]
     fn events_to_bitmask_one_event() {
-        let result = events_to_bitmask(&[OpenVpnPluginEvent::Up]);
+        let result = events_to_bitmask(&[EventType::Up]);
         assert_eq!(0b1, result);
     }
 
     #[test]
     fn events_to_bitmask_another_event() {
-        let result = events_to_bitmask(&[OpenVpnPluginEvent::RouteUp]);
+        let result = events_to_bitmask(&[EventType::RouteUp]);
         assert_eq!(0b100, result);
     }
 
     #[test]
     fn events_to_bitmask_many_events() {
-        let result = events_to_bitmask(&[OpenVpnPluginEvent::RouteUp, OpenVpnPluginEvent::N]);
-        assert_eq!((1 << 13) | (1 << 2), result);
+        let result = events_to_bitmask(&[EventType::RouteUp, EventType::RoutePredown]);
+        assert_eq!((1 << 12) | (1 << 2), result);
     }
 }


### PR DESCRIPTION
We previously discussed how to convert to and from C integer representations on enums bridging between FFI and Rust. We found the `enum-repr` crate that looked useful. I tried using that on our enum right here. It works, but it has a small quirk, it does not work if the enum has documentation. Our current documentation for this enum was quite bad anyway, so I removed it. I also have a PR towards `enum-repr` to fix this: https://github.com/dmnsafonov/enum-repr/pull/2

I have long felt the `OpenVpnPluginEvent` name was long, unwieldy and not perfectly fitting. So I renamed it to `EventType` instead. That matches with the C side, where it's called `event_type` and it also looks much more in line with `EventResult` that we have next to it here in this crate.

Also exposed the `types` module types at the crate root. No need to hide them down there, the crate root has an extremely small and easily understood namespace anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/12)
<!-- Reviewable:end -->
