### PR TITLE
Upgrade to rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rust:
   - stable
   - beta
   - nightly
+  # Oldest supported version
+  - 1.31.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Prepare for Rust 2018. New required minimum Rustc is 1.30.
+- Upgrade to Rust 2018. New required minimum Rust version is 1.31.0.
 - Rename `OpenVpnPluginEvent` to `EventType`.
 - Rename `EventType::from_int` to `from_repr` and make it return `None` on failure instead of error.
 - Make `types` module private and re-export `EventType` plus `EventResult` at crate root.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["openvpn", "vpn", "plugin", "ffi", "cdylib"]
 categories = ["api-bindings", "external-ffi-bindings", "network-programming"]
 repository = "https://github.com/mullvad/openvpn-plugin-rs"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/debug-plugin/Cargo.toml
+++ b/debug-plugin/Cargo.toml
@@ -3,6 +3,7 @@ name = "debug-plugin"
 version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>"]
 description = "An example/debug OpenVPN plugin. Showing the features of openvpn-plugin"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -9,8 +9,6 @@
 //! This debug/example OpenVPN plugin listens for almost all events and prints the arguments
 //! for each event callback and returns success in every case.
 
-extern crate openvpn_plugin;
-
 use openvpn_plugin::{EventResult, EventType};
 use std::collections::HashMap;
 use std::ffi::CString;

--- a/src/ffi/parse.rs
+++ b/src/ffi/parse.rs
@@ -24,7 +24,7 @@ pub enum ParseError {
 }
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             ParseError::NullPtr => f.write_str(self.description()),
             ParseError::NoEqual(ref s) => write!(f, "No equal sign in \"{}\"", s.to_string_lossy()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,10 @@
 //! [`openvpn_plugin!`] macro.
 //!
 //! ```rust,no_run
-//! #[macro_use]
-//! extern crate openvpn_plugin;
-//!
 //! use std::collections::HashMap;
 //! use std::ffi::CString;
 //! use std::io::Error;
-//! use openvpn_plugin::{EventResult, EventType};
+//! use openvpn_plugin::{openvpn_plugin, EventResult, EventType};
 //!
 //! pub struct Handle {
 //!     // Fields needed for the plugin to keep state between callbacks
@@ -72,7 +69,7 @@
 //!     Ok(EventResult::Success)
 //! }
 //!
-//! openvpn_plugin!(::openvpn_open, ::openvpn_close, ::openvpn_event, Handle);
+//! openvpn_plugin!(crate::openvpn_open, crate::openvpn_close, crate::openvpn_event, Handle);
 //! # fn main() {}
 //! ```
 //!
@@ -101,11 +98,6 @@
 #[cfg(feature = "serde")]
 #[cfg_attr(feature = "serde", macro_use)]
 extern crate serde;
-
-#[cfg(feature = "log")]
-extern crate log;
-
-extern crate derive_try_from_primitive;
 
 use std::{
     collections::HashMap,
@@ -425,7 +417,7 @@ where
 #[derive(Debug)]
 struct Error {
     msg: &'static str,
-    cause: Box<::std::error::Error>,
+    cause: Box<dyn (::std::error::Error)>,
 }
 
 impl Error {
@@ -435,13 +427,13 @@ impl Error {
     {
         Error {
             msg,
-            cause: Box::new(cause) as Box<::std::error::Error>,
+            cause: Box::new(cause) as Box<dyn (::std::error::Error)>,
         }
     }
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use std::error::Error;
         self.description().fmt(f)
     }
@@ -452,7 +444,7 @@ impl ::std::error::Error for Error {
         self.msg
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         Some(self.cause.as_ref())
     }
 }
@@ -462,7 +454,7 @@ impl ::std::error::Error for Error {
 struct InvalidEventType(c_int);
 
 impl fmt::Display for InvalidEventType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{} is not a valid OPENVPN_PLUGIN_* constant", self.0)
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,7 +15,7 @@ pub fn log_error(error: &impl Error) {
     }
 }
 
-pub fn log_panic(source: &str, panic_payload: &Box<Any + Send + 'static>) {
+pub fn log_panic(source: &str, panic_payload: &Box<dyn Any + Send + 'static>) {
     let panic_msg = panic_payload
         .downcast_ref::<&str>()
         .unwrap_or(&"No panic message");


### PR DESCRIPTION
Slowly getting a feel for Rust 2018 by upgrading some small libraries we have. This one did not require many changes at all.

Most of this was done automatically by `cargo fix --edition` and `cargo fix --edition-idioms`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/13)
<!-- Reviewable:end -->
