### PR TITLE
Upgrade derive-try-from-primitive to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
   - beta
   - nightly
   # Oldest supported version
-  - 1.40.0
+  - 1.42.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Modernize the error types. Remove `Error::description` implementation (in favor of just using
   the `Display` implementation) and change `Error::cause` into `Error::source`.
 - Make `EventType` a `#[non_exhaustive]` enum to allow conditionally adding variants with features.
+- `EventType` now implements `std::convert::TryFrom` instead of having custom `try_from` method.
+  Returns a `Result<Self, i32>` instead of `Option<Self>`.
 
 ### Removed
 - The `EventType::N` variant. It is not a real event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Mullvad VPN specific]: https://github.com/mullvad/openvpn
 
 ### Changed
-- Upgrade to Rust 2018. New required minimum Rust version is 1.40.0 (#[non_exhaustive]).
+- Upgrade to Rust 2018. New required minimum Rust version (MSRV) is 1.42.0 due to
+  #[non_exhaustive] and `proc_macro::TokenStream`.
 - Rename `OpenVpnPluginEvent` to `EventType`.
 - Rename `EventType::from_int` to `from_repr` and make it return `None` on failure instead of error.
 - Make `types` module private and re-export `EventType` plus `EventResult` at crate root.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ auth-failed-event = []
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 log = { version = "0.4", optional = true }
-derive-try-from-primitive = "0.1.0"
+derive-try-from-primitive = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ extern crate serde;
 
 use std::{
     collections::HashMap,
+    convert::TryFrom,
     ffi::CString,
     fmt,
     os::raw::{c_int, c_void},
@@ -382,7 +383,7 @@ where
 {
     let event_type = (*args).event_type;
     let event = try_or_return_error!(
-        EventType::try_from(event_type).ok_or_else(|| InvalidEventType(event_type)),
+        EventType::try_from(event_type).map_err(|_| InvalidEventType(event_type)),
         "Invalid event integer"
     );
     let parsed_args = try_or_return_error!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,6 +79,7 @@ pub enum EventResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
 
     #[test]
     fn event_enum_to_str() {
@@ -116,8 +117,8 @@ mod tests {
         #[cfg(feature = "auth-failed-event")]
         assert_eq!(auth_failed.unwrap(), EventType::AuthFailed);
         #[cfg(not(feature = "auth-failed-event"))]
-        assert!(auth_failed.is_none());
+        assert_eq!(auth_failed, Err(13));
 
-        assert!(EventType::try_from(14).is_none());
+        assert_eq!(EventType::try_from(14), Err(14));
     }
 }


### PR DESCRIPTION
As a final cleanup before publishing, let's make sure we depend on the latest versions of all dependencies. The only one I had to upgrade was `derive-try-from-primitive`. Luckily it has reached 1.0, which is good for stability I guess. The difference is that the derive macro now implements the standard library `TryFrom` trait rather than adding a custom `try_from` method. So the return type is now `Result<Self, [repr int type]>` instead of `Option<Self>`. Code adapted to that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/15)
<!-- Reviewable:end -->
