### PR TITLE
Add new event types for OpenVPN 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `EventType::AuthFailed` behind a feature (`auth-failed-event`). Allows the plugin to process
   the [Mullvad VPN specific] event in the fork.
+- Add event types `ClientConnectDefer` and `ClientConnectDeferV2`, new in OpenVPN 2.5.
 
 [Mullvad VPN specific]: https://github.com/mullvad/openvpn
 

--- a/debug-plugin/src/lib.rs
+++ b/debug-plugin/src/lib.rs
@@ -30,6 +30,8 @@ pub static INTERESTING_EVENTS: &[EventType] = &[
     EventType::TlsFinal,
     EventType::EnablePf,
     EventType::RoutePredown,
+    EventType::ClientConnectDefer,
+    EventType::ClientConnectDeferV2,
     #[cfg(feature = "auth-failed-event")]
     EventType::AuthFailed,
 ];

--- a/src/types.rs
+++ b/src/types.rs
@@ -115,12 +115,12 @@ mod tests {
 
     #[test]
     fn events_max_value() {
-        let auth_failed = EventType::try_from(13);
+        let auth_failed = EventType::try_from(15);
         #[cfg(feature = "auth-failed-event")]
         assert_eq!(auth_failed.unwrap(), EventType::AuthFailed);
         #[cfg(not(feature = "auth-failed-event"))]
-        assert_eq!(auth_failed, Err(13));
+        assert_eq!(auth_failed, Err(15));
 
-        assert_eq!(EventType::try_from(14), Err(14));
+        assert_eq!(EventType::try_from(16), Err(16));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,8 +34,10 @@ pub enum EventType {
     TlsFinal = 10,
     EnablePf = 11,
     RoutePredown = 12,
+    ClientConnectDefer = 13,
+    ClientConnectDeferV2 = 14,
     #[cfg(feature = "auth-failed-event")]
-    AuthFailed = 13,
+    AuthFailed = 15,
 }
 
 /// Translates a collection of `EventType` instances into a bitmask in the format OpenVPN


### PR DESCRIPTION
OpenVPN 2.5 adds a couple of new plugin events. The numeric value of `AuthFailed` has also been changed to `15`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/16)
<!-- Reviewable:end -->
