### PR TITLE
Add `ClientCrResponse` event type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add event type `ClientCrresponse`, new in OpenVPN 2.6.
+
+### Removed
+- Remove deprecated `EnablePf` event type.
+
 ## [0.4.1] - 2021-01-12
 ### Fixed
 - Fix broken markdown in documentation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ macro_rules! try_or_return_error {
                 logging::log_error(&Error::new($error_msg, e));
                 return ffi::OPENVPN_PLUGIN_FUNC_ERROR;
             }
-        };
+        }
     };
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,12 +32,13 @@ pub enum EventType {
     LearnAddress = 8,
     ClientConnectV2 = 9,
     TlsFinal = 10,
-    EnablePf = 11,
+    //EnablePf = 11, // feature has been removed as of OpenVPN 2.6
     RoutePredown = 12,
     ClientConnectDefer = 13,
     ClientConnectDeferV2 = 14,
+    ClientCrresponse = 15,
     #[cfg(feature = "auth-failed-event")]
-    AuthFailed = 15,
+    AuthFailed = 16,
 }
 
 /// Translates a collection of `EventType` instances into a bitmask in the format OpenVPN


### PR DESCRIPTION
This adds an event `ClientCrResponse` and bumps the event number for `AuthFailed` to 16.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/18)
<!-- Reviewable:end -->
