### PR TITLE
Add deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Deprecated
+- Deprecate `openvpn-plugin`.
+
 
 ## [0.4.2] - 2023-02-20
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ categories = ["api-bindings", "external-ffi-bindings", "network-programming"]
 repository = "https://github.com/mullvad/openvpn-plugin-rs"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+readme = "./README.md"
 
 [features]
 # Adds `EventType::AuthFailed`. This plugin event is specific to the Mullvad VPN fork of OpenVPN,

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# openvpn-plugin-rs
+> NOTE: This crate is deprecated. No new feature development will happen in this crate.


### PR DESCRIPTION
Mullvad no longer has a use for this crate, and we don't intend to maintain it.

Added a README with a deprecation notice as recommended by https://forge.rust-lang.org/policies/crate-ownership.html. Let's cute a last release after this PR has been merged and then deprecate it on crates.io.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/23)
<!-- Reviewable:end -->
