### PR TITLE
Release `0.4.3` - the final release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+
+## [0.4.3] - 2025-11-20
 ### Deprecated
 - Deprecate `openvpn-plugin`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openvpn-plugin"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Mullvad VPN", "Linus Färnstrand <linus@mullvad.net>"]
 description = "A crate allowing easy creation of OpenVPN plugins in Rust"
 keywords = ["openvpn", "vpn", "plugin", "ffi", "cdylib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,7 +419,7 @@ where
 #[derive(Debug)]
 struct Error {
     msg: &'static str,
-    source: Box<dyn (::std::error::Error)>,
+    source: Box<dyn ::std::error::Error>,
 }
 
 impl Error {


### PR DESCRIPTION
The release has already been tagged and [published on crates.io](https://crates.io/crates/openvpn-plugin). Let's merge the release tag to `main` before archiving the GitHub repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/openvpn-plugin-rs/24)
<!-- Reviewable:end -->
